### PR TITLE
Add unicode_truncate_start method.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,13 +134,13 @@ impl UnicodeTruncateStr for str {
             return (self, new_width);
         }
 
-        let mut char_indices = s.char_indices();
+        let mut char_indices = self.char_indices();
         while let Some((_, c)) = char_indices.next() {
             new_width -= c.width().unwrap_or(0);
             if new_width <= width {
                 return match char_indices.next() {
-                    None => (s.get(..0).unwrap(), 0),
-                    Some((i, _)) => (s.get(i..).unwrap(), new_width),
+                    None => (self.get(..0).unwrap(), 0),
+                    Some((i, _)) => (self.get(i..).unwrap(), new_width),
                 };
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,7 @@ impl UnicodeTruncateStr for str {
         for (bidx, c) in self.char_indices() {
             new_width = new_width - c.width().unwrap_or(0);
             if new_width <= width {
-                return (self.get(..bidx).unwrap(), new_width);
+                return (self.get(bidx..).unwrap(), new_width);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ use unicode_width::UnicodeWidthStr;
 
 /// Methods for padding or truncating using displayed width of Unicode strings.
 pub trait UnicodeTruncateStr {
-    /// Truncates a string to be at most `width` in terms of display width, keeping the left-most
+    /// Truncates a string to be at most `width` in terms of display width by removing the end
     /// characters.
     ///
     /// For wide characters, it may not always be possible to truncate at exact width. In this case,
@@ -61,7 +61,7 @@ pub trait UnicodeTruncateStr {
     /// * `width` - the maximum display width
     fn unicode_truncate(&self, width: usize) -> (&str, usize);
 
-    /// Truncates a string to be at most `width` in terms of display width, keeping the right-most
+    /// Truncates a string to be at most `width` in terms of display width by removing the start
     /// characters.
     ///
     /// For wide characters, it may not always be possible to truncate at exact width. In this case,
@@ -73,7 +73,7 @@ pub trait UnicodeTruncateStr {
     ///
     /// # Arguments
     /// * `width` - the maximum display width
-    fn unicode_truncate_left(&self, width: usize) -> (&str, usize);
+    fn unicode_truncate_start(&self, width: usize) -> (&str, usize);
 
     /// Pads a string to be `width` in terms of display width.
     /// Only available when the `std` feature of this library is activated,
@@ -122,7 +122,7 @@ impl UnicodeTruncateStr for str {
     }
     
     #[inline]
-    fn unicode_truncate_left(&self, width: usize) -> (&str, usize) {
+    fn unicode_truncate_start(&self, width: usize) -> (&str, usize) {
         // bail out fast
         if width == 0 {
             return (self.get(..0).unwrap(), 0);


### PR DESCRIPTION
I found that I wanted to truncate the start of my string, and I was surprised this crate doesn't provide it, so I decided to try and add it.

I think it would also be a good idea to bump unicode_width to the latest version, 0.1.8.