### PR TITLE
Simplify code and truncate centered

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "unicode-truncate"
 version = "0.2.0"
 authors = ["Aetf <aetf@unlimitedcodeworks.xyz>"]
 edition = "2018"
+rust-version = "1.38.0"
 
 homepage = "https://github.com/Aetf/unicode-truncate"
 repository = "https://github.com/Aetf/unicode-truncate"
@@ -20,10 +21,10 @@ exclude = [
 travis-ci = { repository = "Aetf/unicode-truncate" }
 
 [dependencies]
-unicode-width = "0.1.8"
+unicode-width = "0.1"
 
 [dev-dependencies]
-criterion = "0.3.3"
+criterion = "0.4"
 
 [lib]
 bench = false

--- a/README.md
+++ b/README.md
@@ -1,37 +1,40 @@
 # unicode-truncate
+
 Unicode-aware algorithm to pad or truncate `str` in terms of displayed width.
 
 [![crates.io](https://img.shields.io/crates/v/unicode-truncate.svg)](https://crates.io/crates/unicode-truncate)
 [![Documentation](https://docs.rs/unicode-truncate/badge.svg)](https://docs.rs/unicode-truncate)
 [![Build Status](https://travis-ci.com/Aetf/unicode-truncate.svg)](https://travis-ci.com/Aetf/unicode-truncate)
 
-## examples
+## Examples
+
 Safely truncate string to display width even not at character boundaries.
+
 ```rust
 use unicode_truncate::UnicodeTruncateStr;
 
 fn main() {
-    let (rv, w) = "你好吗".unicode_truncate(5);
-    assert_eq!(rv, "你好");
-    assert_eq!(w, 4);
+    assert_eq!("你好吗".unicode_truncate(5), ("你好", 4));
 }
 ```
 
-Making sure the string is displayed in exactly number of columns by combining padding
-and truncating.
+Making sure the string is displayed in exactly number of columns by combining padding and
+truncating.
+
 ```rust
 use unicode_truncate::UnicodeTruncateStr;
 use unicode_truncate::Alignment;
 use unicode_width::UnicodeWidthStr;
 
 fn main() {
-    let rv = "你好吗".unicode_pad(5, Alignment::Left, true);
-    assert_eq!(rv, "你好 ");
-    assert_eq!(rv.width(), 5);
+    let str = "你好吗".unicode_pad(5, Alignment::Left, true);
+    assert_eq!(str, "你好 ");
+    assert_eq!(str.width(), 5);
 }
 ```
 
-## features
-`unicode-truncate` can be built without libstd by disabling the default feature `std`. However in that
-case `unicode_truncate::UnicodeTruncateStr::unicode_pad` won't be available because it depends on
-`std::string::String` and `std::borrow::Cow`.
+## Features
+
+`unicode-truncate` can be built without `std` by disabling the default feature `std`. However, in
+that case `unicode_truncate::UnicodeTruncateStr::unicode_pad` won't be available because it depends
+on `std::string::String` and `std::borrow::Cow`.

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,30 +1,32 @@
-use criterion::{criterion_group, criterion_main, Criterion, Throughput, BenchmarkId};
-
-use unicode_truncate::UnicodeTruncateStr;
 use std::time::Duration;
 
-fn roughly_cut(s: &str, size: usize) -> &str {
-    if size >= s.len() {
-        return s;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use unicode_truncate::UnicodeTruncateStr;
+
+fn roughly_cut(str: &str, size: usize) -> &str {
+    if size >= str.len() {
+        return str;
     }
     let mut end = size;
-    while !s.is_char_boundary(end) {
+    while !str.is_char_boundary(end) {
         end += 1;
     }
-    &s[..end]
+    &str[..end]
 }
 
-fn criterion_benchmark(c: &mut Criterion) {
+fn criterion_benchmark(criterion: &mut Criterion) {
     static KB: usize = 1024;
     static TEXT: &str = include_str!("data/zhufu.txt");
 
-    let mut group = c.benchmark_group("zhu fu");
-    group.sample_size(1000).measurement_time(Duration::from_secs(20));
-    for size in [KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB, 28 * KB].iter() {
-        let s = roughly_cut(TEXT, *size);
+    let mut group = criterion.benchmark_group("zhu fu");
+    group
+        .sample_size(1000)
+        .measurement_time(Duration::from_secs(20));
+    for size in &[KB, 2 * KB, 4 * KB, 8 * KB, 16 * KB, 28 * KB] {
+        let str = roughly_cut(TEXT, *size);
         group.throughput(Throughput::Bytes(*size as u64));
-        group.bench_with_input(BenchmarkId::from_parameter(size), s, |b, s| {
-            b.iter(|| s.unicode_truncate(s.len() / 2));
+        group.bench_with_input(BenchmarkId::from_parameter(size), str, |bench, str| {
+            bench.iter(|| str.unicode_truncate(str.len() / 2));
         });
     }
     group.finish();

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -32,6 +32,9 @@ fn criterion_benchmark(criterion: &mut Criterion) {
         group.bench_with_input("start", input, |bench, str| {
             bench.iter(|| str.unicode_truncate_start(max_width));
         });
+        group.bench_with_input("centered", input, |bench, str| {
+            bench.iter(|| str.unicode_truncate_centered(max_width));
+        });
         group.finish();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,7 +166,11 @@ impl UnicodeTruncateStr for str {
             .take_while(|&(_, current_width)| current_width <= max_width)
             .last()
             .unwrap_or((0, 0));
-        (self.get(..byte_index).unwrap(), new_width)
+
+        // unwrap is safe as the index comes from char_indices
+        let result = self.get(..byte_index).unwrap();
+        debug_assert_eq!(result.width(), new_width);
+        (result, new_width)
     }
 
     #[inline]
@@ -185,7 +189,11 @@ impl UnicodeTruncateStr for str {
             .take_while(|&(_, current_width)| current_width <= max_width)
             .last()
             .unwrap_or((self.len(), 0));
-        (self.get(byte_index..).unwrap(), new_width)
+
+        // unwrap is safe as the index comes from char_indices
+        let result = self.get(byte_index..).unwrap();
+        debug_assert_eq!(result.width(), new_width);
+        (result, new_width)
     }
 
     #[allow(clippy::collapsible_else_if)]
@@ -241,6 +249,7 @@ impl UnicodeTruncateStr for str {
             0
         };
 
+        // unwrap is safe as the index comes from char_indices
         let result = self.get(start_index..end_index).unwrap();
         debug_assert_eq!(result.width(), current_width);
         (result, current_width)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright 2019 Aetf <aetf at unlimitedcodeworks dot xyz>. See the COPYRIGHT
-// file at the top-level directory of this distribution.
+// Copyright 2019 Aetf <aetf at unlimitedcodeworks dot xyz>.
+// See the COPYRIGHT file at the top-level directory of this distribution.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -7,21 +7,20 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![forbid(missing_docs, unsafe_code)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
 //! Unicode-aware algorithm to pad or truncate `str` in terms of displayed width.
 //!
-//! See the [UnicodeTruncateStr](crate::UnicodeTruncateStr) trait for new methods
-//! available on `str`.
+//! See the [UnicodeTruncateStr](crate::UnicodeTruncateStr) trait for new methods available on
+//! `str`.
 //!
 //! # Examples
 //! Safely truncate string to display width even not at character boundaries.
 //! ```rust
 //! use unicode_truncate::UnicodeTruncateStr;
-//!
-//! let (rv, w) = "你好吗".unicode_truncate(5);
-//! assert_eq!(rv, "你好");
-//! assert_eq!(w, 4);
+//! assert_eq!("你好吗".unicode_truncate(5), ("你好", 4));
 //! ```
-//!
 #![cfg_attr(
     feature = "std",
     doc = r##"
@@ -33,19 +32,28 @@ use unicode_truncate::UnicodeTruncateStr;
 use unicode_truncate::Alignment;
 use unicode_width::UnicodeWidthStr;
 
-let rv = "你好吗".unicode_pad(5, Alignment::Left, true);
-assert_eq!(rv, "你好 ");
-assert_eq!(rv.width(), 5);
+let str = "你好吗".unicode_pad(5, Alignment::Left, true);
+assert_eq!(str, "你好 ");
+assert_eq!(str.width(), 5);
 ```
 "##
 )]
-#![deny(missing_docs, unsafe_code)]
-#![cfg_attr(not(feature = "std"), no_std)]
-
-use core::iter;
 
 use unicode_width::UnicodeWidthChar;
-use unicode_width::UnicodeWidthStr;
+
+/// Defines the alignment for padding.
+/// Only available when the `std` feature of this library is activated,
+/// and it is activated by default.
+#[cfg(feature = "std")]
+#[derive(PartialEq, Eq, Debug, Copy, Clone)]
+pub enum Alignment {
+    /// Align to the left
+    Left,
+    /// Align center
+    Center,
+    /// Align to the right
+    Right,
+}
 
 /// Methods for padding or truncating using displayed width of Unicode strings.
 pub trait UnicodeTruncateStr {
@@ -56,12 +64,12 @@ pub trait UnicodeTruncateStr {
     /// the longest possible string is returned. To help the caller determine the situation, the
     /// display width of the returned string slice is also returned.
     ///
-    /// Zero-width characters decided by [unicode_width](::unicode_width) are always included when
-    /// deciding the truncation point.
+    /// Zero-width characters decided by [`unicode_width`] are always included when deciding the
+    /// truncation point.
     ///
     /// # Arguments
-    /// * `width` - the maximum display width
-    fn unicode_truncate(&self, width: usize) -> (&str, usize);
+    /// * `max_width` - the maximum display width
+    fn unicode_truncate(&self, max_width: usize) -> (&str, usize);
 
     /// Truncates a string to be at most `width` in terms of display width by removing the start
     /// characters.
@@ -70,30 +78,30 @@ pub trait UnicodeTruncateStr {
     /// the longest possible string is returned. To help the caller determine the situation, the
     /// display width of the returned string slice is also returned.
     ///
-    /// Zero-width characters decided by [unicode_width](::unicode_width) are always included when
-    /// deciding the truncation point.
+    /// Zero-width characters decided by [`unicode_width`] are always included when deciding the
+    /// truncation point.
     ///
     /// # Arguments
-    /// * `width` - the maximum display width
-    fn unicode_truncate_start(&self, width: usize) -> (&str, usize);
+    /// * `max_width` - the maximum display width
+    fn unicode_truncate_start(&self, max_width: usize) -> (&str, usize);
 
-    /// Pads a string to be `width` in terms of display width.
-    /// Only available when the `std` feature of this library is activated,
-    /// and it is activated by default.
+    /// Pads a string to be `width` in terms of display width. Only available when the `std` feature
+    /// of this library is activated, and it is activated by default.
     ///
     /// When `truncate` is true, the string is truncated to `width` if necessary. In case of wide
-    /// characters and truncation point not at character boundary, the longest possible string
-    /// is used, and padded to exact `width` according to `align`.
-    /// See [unicode_truncate](crate::UnicodeTruncateStr::unicode_truncate) for the behavior of truncation.
+    /// characters and truncation point not at character boundary, the longest possible string is
+    /// used, and padded to exact `width` according to `align`.
+    /// See [`unicode_truncate`](crate::UnicodeTruncateStr::unicode_truncate) for the behavior of
+    /// truncation.
     ///
     /// # Arguments
-    /// * `width` - the display width to pad to
+    /// * `target_width` - the display width to pad to
     /// * `align` - alignment for padding
     /// * `truncate` - whether to truncate string if necessary
     #[cfg(feature = "std")]
     fn unicode_pad(
         &self,
-        width: usize,
+        target_width: usize,
         align: Alignment,
         truncate: bool,
     ) -> std::borrow::Cow<'_, str>;
@@ -101,95 +109,68 @@ pub trait UnicodeTruncateStr {
 
 impl UnicodeTruncateStr for str {
     #[inline]
-    fn unicode_truncate(&self, width: usize) -> (&str, usize) {
-        let (bidx, new_width) = self.char_indices()
+    fn unicode_truncate(&self, max_width: usize) -> (&str, usize) {
+        let (byte_index, new_width) = self
+            .char_indices()
             // map to byte index and the width of char start at the index
-            .map(|(bidx, c)| (bidx, c.width().unwrap_or(0)))
+            .map(|(byte_index, char)| (byte_index, char.width().unwrap_or(0)))
             // chain a final element representing the position past the last char
-            .chain(iter::once((self.len(), 0)))
+            .chain(core::iter::once((self.len(), 0)))
             // fold to byte index and the width up to the index
-            .scan(0, |w, (bidx, cw)| {
-                let curr_w = *w;
-                *w = *w + cw;
-                Some((bidx, curr_w))
+            .scan(0, |sum, (byte_index, char_width)| {
+                let current_width = *sum;
+                *sum += char_width;
+                Some((byte_index, current_width))
             })
             // take the longest but still shorter than requested
-            .take_while(|&(_, w)| w <= width)
+            .take_while(|&(_, current_width)| current_width <= max_width)
             .last()
             .unwrap_or((0, 0));
-        (self.get(..bidx).unwrap(), new_width)
+        (self.get(..byte_index).unwrap(), new_width)
     }
 
     #[inline]
-    fn unicode_truncate_start(&self, width: usize) -> (&str, usize) {
-        let (bidx, new_width) = iter::once((self.len(), 0))
+    fn unicode_truncate_start(&self, max_width: usize) -> (&str, usize) {
+        let (byte_index, new_width) = core::iter::once((self.len(), 0))
             .chain(
                 self.char_indices()
                     .rev()
-                    .map(|(bidx, c)| (bidx, c.width().unwrap_or(0)))
+                    .map(|(byte_index, char)| (byte_index, char.width().unwrap_or(0))),
             )
             // fold to byte index and the width from end to the index
-            .scan(0, |w, (bidx, cw)| {
-                *w = *w + cw;
-                Some((bidx, *w))
+            .scan(0, |sum, (byte_index, char_width)| {
+                *sum += char_width;
+                Some((byte_index, *sum))
             })
-            .take_while(|&(_, w)| w <= width)
+            .take_while(|&(_, current_width)| current_width <= max_width)
             .last()
             .unwrap_or((self.len(), 0));
-
-        (self.get(bidx..).unwrap(), new_width)
+        (self.get(byte_index..).unwrap(), new_width)
     }
 
     #[cfg(feature = "std")]
     #[inline]
     fn unicode_pad(
         &self,
-        width: usize,
+        target_width: usize,
         align: Alignment,
         truncate: bool,
     ) -> std::borrow::Cow<'_, str> {
-        pad::unicode_pad(self, width, align, truncate)
-    }
-}
+        use std::borrow::Cow;
 
-#[cfg(feature = "std")]
-mod pad {
-    use super::*;
-    pub use std::borrow::Cow;
+        use unicode_width::UnicodeWidthStr;
 
-    /// Defines the alignment for padding.
-    /// Only available when the `std` feature of this library is activated,
-    /// and it is activated by default.
-    #[derive(PartialEq, Eq, Debug, Copy, Clone)]
-    pub enum Alignment {
-        /// Align to the left
-        Left,
-        /// Align center
-        Center,
-        /// Align to the right
-        Right,
-    }
+        if !truncate && self.width() >= target_width {
+            return Cow::Borrowed(self);
+        }
 
-    pub fn unicode_pad(s: &str, width: usize, align: Alignment, truncate: bool) -> Cow<'_, str> {
-        let mut cols = s.width();
-        let mut cs = Cow::Borrowed(s);
-
-        if cols >= width {
-            if !truncate {
-                return Cow::Borrowed(s);
-            }
-            {
-                let (new_s, new_cols) = s.unicode_truncate(width);
-                cs = Cow::Borrowed(new_s);
-                cols = new_cols;
-            }
-            if cols == width {
-                return cs;
-            }
+        let (truncated, columns) = self.unicode_truncate(target_width);
+        if columns == target_width {
+            return Cow::Borrowed(truncated);
         }
 
         // the string is less than width, or truncated to less than width
-        let diff = width.saturating_sub(cols);
+        let diff = target_width.saturating_sub(columns);
 
         let (left_pad, right_pad) = match align {
             Alignment::Left => (0, diff),
@@ -197,20 +178,17 @@ mod pad {
             Alignment::Center => (diff / 2, diff.saturating_sub(diff / 2)),
         };
 
-        let mut rv = String::new();
-        rv.reserve(left_pad + cs.len() + right_pad);
+        let mut result = String::with_capacity(left_pad + truncated.len() + right_pad);
         for _ in 0..left_pad {
-            rv.push(' ');
+            result.push(' ');
         }
-        rv.push_str(&cs);
+        result += truncated;
         for _ in 0..right_pad {
-            rv.push(' ');
+            result.push(' ');
         }
-        Cow::Owned(rv)
+        Cow::Owned(result)
     }
 }
-#[cfg(feature = "std")]
-pub use pad::Alignment;
 
 #[cfg(test)]
 mod tests {
@@ -219,53 +197,31 @@ mod tests {
 
         #[test]
         fn empty() {
-            let (rv, rw) = "".unicode_truncate(4);
-            assert_eq!(rv, "");
-            assert_eq!(rw, 0);
+            assert_eq!("".unicode_truncate(4), ("", 0));
         }
 
         #[test]
         fn zero_width() {
-            let (rv, rw) = "ab".unicode_truncate(0);
-            assert_eq!(rv, "");
-            assert_eq!(rw, 0);
-
-            let (rv, rw) = "你好".unicode_truncate(0);
-            assert_eq!(rv, "");
-            assert_eq!(rw, 0);
+            assert_eq!("ab".unicode_truncate(0), ("", 0));
+            assert_eq!("你好".unicode_truncate(0), ("", 0));
         }
 
         #[test]
         fn less_than_limit() {
-            let (rv, rw) = "abc".unicode_truncate(4);
-            assert_eq!(rv, "abc");
-            assert_eq!(rw, 3);
-
-            let (rv, rw) = "你".unicode_truncate(4);
-            assert_eq!(rv, "你");
-            assert_eq!(rw, 2);
+            assert_eq!("abc".unicode_truncate(4), ("abc", 3));
+            assert_eq!("你".unicode_truncate(4), ("你", 2));
         }
 
         #[test]
         fn at_boundary() {
-            let (rv, rw) = "boundary".unicode_truncate(5);
-            assert_eq!(rv, "bound");
-            assert_eq!(rw, 5);
-
-            let (rv, rw) = "你好吗".unicode_truncate(4);
-            assert_eq!(rv, "你好");
-            assert_eq!(rw, 4);
+            assert_eq!("boundary".unicode_truncate(5), ("bound", 5));
+            assert_eq!("你好吗".unicode_truncate(4), ("你好", 4));
         }
 
         #[test]
         fn not_boundary() {
-            let (rv, rw) = "你好吗".unicode_truncate(3);
-            assert_eq!(rv, "你");
-            assert_eq!(rw, 2);
-
-            let (rv, rw) = "你好吗".unicode_truncate(1);
-            assert_eq!(rv, "");
-            assert_eq!(rw, 0);
+            assert_eq!("你好吗".unicode_truncate(3), ("你", 2));
+            assert_eq!("你好吗".unicode_truncate(1), ("", 0));
         }
     }
 
@@ -274,53 +230,31 @@ mod tests {
 
         #[test]
         fn empty() {
-            let (rv, rw) = "".unicode_truncate_start(4);
-            assert_eq!(rv, "");
-            assert_eq!(rw, 0);
+            assert_eq!("".unicode_truncate_start(4), ("", 0));
         }
 
         #[test]
         fn zero_width() {
-            let (rv, rw) = "ab".unicode_truncate_start(0);
-            assert_eq!(rv, "");
-            assert_eq!(rw, 0);
-
-            let (rv, rw) = "你好".unicode_truncate_start(0);
-            assert_eq!(rv, "");
-            assert_eq!(rw, 0);
+            assert_eq!("ab".unicode_truncate_start(0), ("", 0));
+            assert_eq!("你好".unicode_truncate_start(0), ("", 0));
         }
 
         #[test]
         fn less_than_limit() {
-            let (rv, rw) = "abc".unicode_truncate_start(4);
-            assert_eq!(rv, "abc");
-            assert_eq!(rw, 3);
-
-            let (rv, rw) = "你".unicode_truncate_start(4);
-            assert_eq!(rv, "你");
-            assert_eq!(rw, 2);
+            assert_eq!("abc".unicode_truncate_start(4), ("abc", 3));
+            assert_eq!("你".unicode_truncate_start(4), ("你", 2));
         }
 
         #[test]
         fn at_boundary() {
-            let (rv, rw) = "boundary".unicode_truncate_start(5);
-            assert_eq!(rv, "ndary");
-            assert_eq!(rw, 5);
-
-            let (rv, rw) = "你好吗".unicode_truncate_start(4);
-            assert_eq!(rv, "好吗");
-            assert_eq!(rw, 4);
+            assert_eq!("boundary".unicode_truncate_start(5), ("ndary", 5));
+            assert_eq!("你好吗".unicode_truncate_start(4), ("好吗", 4));
         }
 
         #[test]
         fn not_boundary() {
-            let (rv, rw) = "你好吗".unicode_truncate_start(3);
-            assert_eq!(rv, "吗");
-            assert_eq!(rw, 2);
-
-            let (rv, rw) = "你好吗".unicode_truncate_start(1);
-            assert_eq!(rv, "");
-            assert_eq!(rw, 0);
+            assert_eq!("你好吗".unicode_truncate_start(3), ("吗", 2));
+            assert_eq!("你好吗".unicode_truncate_start(1), ("", 0));
         }
     }
 
@@ -330,38 +264,28 @@ mod tests {
 
         #[test]
         fn zero_width() {
-            let rv = "你好".unicode_pad(0, Alignment::Left, true);
-            assert_eq!(&rv, "");
-
-            let rv = "你好".unicode_pad(0, Alignment::Left, false);
-            assert_eq!(&rv, "你好");
+            assert_eq!("你好".unicode_pad(0, Alignment::Left, true), "");
+            assert_eq!("你好".unicode_pad(0, Alignment::Left, false), "你好");
         }
 
         #[test]
         fn less_than_limit() {
-            let rv = "你".unicode_pad(4, Alignment::Left, true);
-            assert_eq!(&rv, "你  ");
-            let rv = "你".unicode_pad(4, Alignment::Left, false);
-            assert_eq!(&rv, "你  ");
+            assert_eq!("你".unicode_pad(4, Alignment::Left, true), "你  ");
+            assert_eq!("你".unicode_pad(4, Alignment::Left, false), "你  ");
         }
 
         #[test]
         fn width_at_boundary() {
-            let rv = "你好吗".unicode_pad(4, Alignment::Left, true);
-            assert_eq!(&rv, "你好");
-            let rv = "你好吗".unicode_pad(4, Alignment::Left, false);
-            assert_eq!(&rv, "你好吗");
+            assert_eq!("你好吗".unicode_pad(4, Alignment::Left, true), "你好");
+            assert_eq!("你好吗".unicode_pad(4, Alignment::Left, false), "你好吗");
         }
 
         #[test]
         fn width_not_boundary() {
             // above limit wide chars not at boundary
-            let rv = "你好吗".unicode_pad(3, Alignment::Left, true);
-            assert_eq!(&rv, "你 ");
-            let rv = "你好吗".unicode_pad(1, Alignment::Left, true);
-            assert_eq!(&rv, " ");
-            let rv = "你好吗".unicode_pad(3, Alignment::Left, false);
-            assert_eq!(&rv, "你好吗");
+            assert_eq!("你好吗".unicode_pad(3, Alignment::Left, true), "你 ");
+            assert_eq!("你好吗".unicode_pad(1, Alignment::Left, true), " ");
+            assert_eq!("你好吗".unicode_pad(3, Alignment::Left, false), "你好吗");
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,16 +1,9 @@
-use unicode_truncate::Alignment;
-use unicode_truncate::UnicodeTruncateStr;
+use unicode_truncate::{Alignment, UnicodeTruncateStr};
 
 #[test]
 fn main() {
-    let (rv, w) = "你好吗".unicode_truncate(5);
-    assert_eq!(rv, "你好");
-    assert_eq!(w, 4);
+    assert_eq!("你好吗".unicode_truncate(5), ("你好", 4));
+    assert_eq!("你好吗".unicode_truncate_start(5), ("好吗", 4));
 
-    let (rv, w) = "你好吗".unicode_truncate_start(5);
-    assert_eq!(rv, "好吗");
-    assert_eq!(w, 4);
-
-    let rv = "你好吗".unicode_pad(5, Alignment::Left, true);
-    assert_eq!(rv, "你好 ");
+    assert_eq!("你好吗".unicode_pad(5, Alignment::Left, true), "你好 ");
 }

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -4,7 +4,5 @@ use unicode_truncate::UnicodeTruncateStr;
 
 #[test]
 fn main() {
-    let (rv, w) = "你好吗".unicode_truncate(5);
-    assert_eq!(rv, "你好");
-    assert_eq!(w, 4);
+    assert_eq!("你好吗".unicode_truncate(5), ("你好", 4));
 }


### PR DESCRIPTION
First I simplified the code and used more speaking variable names. Then I started improving the existing code with benchmarks in mind. Then I added two new methods for centered truncation and a helper using the others with Alignment enum.
Take a look at the individual commits for more details on what I did.

The centered approach seems slower than the other two. Originally I planned to replace the begin/end/center methods with a single method, but that's worse performance wise.

I know I changed a lot of code. Feel free to provide what you would like changed / differently. I'll try to do that. I can also split this up into multiple PR when wanted.