### PR TITLE
fix: prevent arithmetic side effects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ exclude = [
     "benches/data/*",
 ]
 
+# Improve benchmark consistency
+[profile.bench]
+codegen-units = 1
+lto = true
+
 [badges]
 travis-ci = { repository = "Aetf/unicode-truncate" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,8 +217,8 @@ impl UnicodeTruncateStr for str {
         // unwrap is safe as original_width > max_width
         let min_removal_width = original_width.checked_sub(max_width).unwrap();
 
-        // around the half (min_removal_width - 2) to take accound into accidentally remove more
-        // than needed due to char width (max 2)
+        // around the half (min_removal_width - 2) to prevent accidentally removing more than needed
+        // due to char width (max 2)
         let less_than_half = min_removal_width.saturating_sub(2) / 2;
 
         let from_start = self


### PR DESCRIPTION
Also results in a small performance benefit due to moving the `skip_while` calculation out of the iterator.