### PR TITLE
fixed typos in the `renovate.json`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:recommended",
     ":automergeMinor",
-    ":group:allNonMajor",
+    "group:allNonMajor"
   ],
   "rangeStrategy": "update-lockfile",
   "automergeStrategy": "squash",

--- a/renovate.json
+++ b/renovate.json
@@ -12,12 +12,12 @@
       "automerge": false,
       "matchCurrentVersion": "< 1.0.0",
       "matchUpdateTypes": [
-        "minor",
+        "minor"
       ]
     },
     {
       "matchDepTypes": ["devDependencies"],
       "automerge": true
-    },
-  ],
+    }
+  ]
 }


### PR DESCRIPTION
During https://github.com/Aetf/unicode-truncate/pull/13 a few typos sneaked in. Among others, that json is not as flexible as many would like about trailing commas

Resolves #14 