### PR TITLE
Treat control characters as width 1, fixes #16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,5 @@ harness = false
 codegen-units = 1
 lto = true
 
+[profile.test]
+debug-assertions = true


### PR DESCRIPTION
This is consistent with how unicode-width handles string width vs char width.

See also https://github.com/unicode-rs/unicode-width/pull/45